### PR TITLE
Fix bug in media upload, add optional detectoin of mime-/file-type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,10 @@ url = "1"
 hyper-old-types = "0.11.0"
 futures-util = "0.3.25"
 
+[dependencies.magic]
+version = "0.13.0"
+optional = true
+
 [dependencies.uuid]
 version = "1.2.2"
 features = ["v4"]
@@ -80,8 +84,9 @@ html2text = "0.4.4"
 version = "0.13"
 
 [features]
-all = ["toml", "json", "env"]
-default = ["reqwest/default-tls"]
+all = ["toml", "json", "env", "magic"]
+# default = ["reqwest/default-tls"]
+default = ["reqwest/default-tls", "magic"]
 env = ["envy"]
 json = []
 rustls-tls = ["reqwest/rustls-tls"]

--- a/examples/upload_photo.rs
+++ b/examples/upload_photo.rs
@@ -30,8 +30,14 @@ async fn main() -> Result<()> {
     femme::with_level(femme::LevelFilter::Trace);
     let mastodon = register::get_mastodon_data().await?;
     let input = register::read_line("Enter the path to the photo you'd like to post: ")?;
+    let description = register::read_line("describe the media?  ")?;
+    let description = if description.trim().is_empty() {
+        None
+    } else {
+        Some(description)
+    };
 
-    let media = mastodon.media(input).await?;
+    let media = mastodon.media(input, description).await?;
     let status = StatusBuilder::new()
         .status("Mastodon-async photo upload example/demo (automated post)")
         .media_ids([media.id])

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -163,33 +163,15 @@ macro_rules! route_v2 {
                 "`, with a description/alt-text.",
                 "\n# Errors\nIf `access_token` is not set."),
             pub async fn $name(&self $(, $param: $typ)*, description: Option<String>) -> Result<$ret> {
-                use reqwest::multipart::{Form, Part};
-                use std::io::Read;
-                use log::{debug, error, as_debug};
+                use reqwest::multipart::Form;
+                use log::{debug, as_debug};
                 use uuid::Uuid;
 
                 let call_id = Uuid::new_v4();
 
                 let form_data = Form::new()
                     $(
-                        .part(stringify!($param), {
-                            let path = $param.as_ref();
-                            match std::fs::File::open(path) {
-                                Ok(mut file) => {
-                                    let mut data = if let Ok(metadata) = file.metadata() {
-                                        Vec::with_capacity(metadata.len().try_into()?)
-                                    } else {
-                                        vec![]
-                                    };
-                                    file.read_to_end(&mut data)?;
-                                    Part::bytes(data)
-                                }
-                                Err(err) => {
-                                    error!(path = as_debug!(path), error = as_debug!(err); "error reading file contents for multipart form");
-                                    return Err(err.into());
-                                }
-                            }
-                        })
+                        .part(stringify!($param), self.get_form_part($param)?)
                      )*;
 
                 let form_data = if let Some(description) = description {
@@ -224,33 +206,16 @@ macro_rules! route_v2 {
                 $url,
                 "`\n# Errors\nIf `access_token` is not set."),
             pub async fn $name(&self, $($param: $typ,)*) -> Result<$ret> {
-                use reqwest::multipart::{Form, Part};
-                use std::io::Read;
-                use log::{debug, error, as_debug};
+                use reqwest::multipart::Form;
+                use log::{debug, as_debug};
                 use uuid::Uuid;
+
 
                 let call_id = Uuid::new_v4();
 
                 let form_data = Form::new()
                     $(
-                        .part(stringify!($param), {
-                            let path = $param.as_ref();
-                            match std::fs::File::open(path) {
-                                Ok(mut file) => {
-                                    let mut data = if let Ok(metadata) = file.metadata() {
-                                        Vec::with_capacity(metadata.len().try_into()?)
-                                    } else {
-                                        vec![]
-                                    };
-                                    file.read_to_end(&mut data)?;
-                                    Part::bytes(data)
-                                }
-                                Err(err) => {
-                                    error!(path = as_debug!(path), error = as_debug!(err); "error reading file contents for multipart form");
-                                    return Err(err.into());
-                                }
-                            }
-                        })
+                        .part(stringify!($param), self.get_form_part($param)?)
                      )*;
 
                 let url = &self.route(concat!("/api/v2/", $url));
@@ -285,33 +250,16 @@ macro_rules! route {
                 $url,
                 "`\n# Errors\nIf `access_token` is not set."),
             pub async fn $name(&self, $($param: $typ,)*) -> Result<$ret> {
-                use reqwest::multipart::{Form, Part};
-                use std::io::Read;
-                use log::{debug, error, as_debug};
+                use reqwest::multipart::Form;
+                use log::{debug, as_debug};
                 use uuid::Uuid;
+
 
                 let call_id = Uuid::new_v4();
 
                 let form_data = Form::new()
                     $(
-                        .part(stringify!($param), {
-                            let path = $param.as_ref();
-                            match std::fs::File::open(path) {
-                                Ok(mut file) => {
-                                    let mut data = if let Ok(metadata) = file.metadata() {
-                                        Vec::with_capacity(metadata.len().try_into()?)
-                                    } else {
-                                        vec![]
-                                    };
-                                    file.read_to_end(&mut data)?;
-                                    Part::bytes(data)
-                                }
-                                Err(err) => {
-                                    error!(path = as_debug!(path), error = as_debug!(err); "error reading file contents for multipart form");
-                                    return Err(err.into());
-                                }
-                            }
-                        })
+                        .part(stringify!($param), self.get_form_part($param)?)
                      )*;
 
                 let url = &self.route(concat!("/api/v1/", $url));
@@ -343,33 +291,16 @@ macro_rules! route {
                 "`, with a description/alt-text.",
                 "\n# Errors\nIf `access_token` is not set."),
             pub async fn $name(&self $(, $param: $typ)*, description: Option<String>) -> Result<$ret> {
-                use reqwest::multipart::{Form, Part};
-                use std::io::Read;
-                use log::{debug, error, as_debug};
+                use reqwest::multipart::Form;
+                use log::{debug, as_debug};
                 use uuid::Uuid;
+
 
                 let call_id = Uuid::new_v4();
 
                 let form_data = Form::new()
                     $(
-                        .part(stringify!($param), {
-                            let path = $param.as_ref();
-                            match std::fs::File::open(path) {
-                                Ok(mut file) => {
-                                    let mut data = if let Ok(metadata) = file.metadata() {
-                                        Vec::with_capacity(metadata.len().try_into()?)
-                                    } else {
-                                        vec![]
-                                    };
-                                    file.read_to_end(&mut data)?;
-                                    Part::bytes(data)
-                                }
-                                Err(err) => {
-                                    error!(path = as_debug!(path), error = as_debug!(err); "error reading file contents for multipart form");
-                                    return Err(err.into());
-                                }
-                            }
-                        })
+                        .part(stringify!($param), self.get_form_part($param)?)
                      )*;
 
                 let form_data = if let Some(description) = description {


### PR DESCRIPTION
A bug was found where the client didn't include any file-type information with media uploads. This change fixes that by making two changes:

1. The path to the file is included in the form now. This is enough to indicate to the Mastodon server what kind of file it is, and results in a 200 Ok response.
2. With the optional, default `"magic"` feature, the file will be inspected to determine what kind of file it is, and the mime-type is included in the form. This may help with debugging and providing more robust error messages in the case where a file's extension is misinterpreted or different from the actual filetype, and could help the server better understand what to do with this file. To turn off this feature, disable the `"magic"` default feature.

This will resolve #6 . Thanks to @ckruse for reporting this bug.