### PR TITLE
Fix discrepancy in server response formats

### DIFF
--- a/examples/post_status.rs
+++ b/examples/post_status.rs
@@ -1,0 +1,43 @@
+#![cfg_attr(not(feature = "toml"), allow(dead_code))]
+#![cfg_attr(not(feature = "toml"), allow(unused_imports))]
+mod register;
+
+use mastodon_async::{Language, Result, StatusBuilder, Visibility};
+
+#[cfg(feature = "toml")]
+#[tokio::main]
+async fn main() -> Result<()> {
+    let mastodon = register::get_mastodon_data().await?;
+    let status = StatusBuilder::new()
+        .status(register::read_line(
+            "Enter a status to post privately (enter to send): ",
+        )?)
+        .visibility(Visibility::Private)
+        .language(Language::Eng)
+        .build()?;
+
+    let status = mastodon.new_status(status).await?;
+
+    print!("Status posted");
+    if let Some(url) = status.url {
+        // this is the expected thing to happen
+        println!(", visible when logged in at: {}\n", url);
+    } else {
+        println!(". For some reason, the status URL was not returned from the server.");
+        println!("Maybe try here? {}/{}", status.account.url, status.id);
+    }
+    if register::bool_input("delete this post? (Y/n)", true)? {
+        mastodon.delete_status(&status.id).await?;
+        println!("ok, done")
+    }
+
+    Ok(())
+}
+
+#[cfg(not(feature = "toml"))]
+fn main() {
+    println!(
+        "examples require the `toml` feature, run this command for this example:\n\ncargo run \
+         --example post_status --features toml\n"
+    );
+}

--- a/examples/register/mod.rs
+++ b/examples/register/mod.rs
@@ -54,5 +54,26 @@ pub fn read_line(message: impl AsRef<str>) -> Result<String> {
     Ok(input.trim().to_string())
 }
 
+#[cfg(feature = "toml")]
+pub fn bool_input(message: impl AsRef<str>, default: bool) -> Result<bool> {
+    let input = read_line(message.as_ref())?;
+    if let Some(first_char) = input.chars().next() {
+        match first_char {
+            'Y' | 'y' => Ok(true),
+            'N' | 'n' => Ok(false),
+            '\n' => Ok(default),
+            _ => {
+                print!(
+                    "I didn't understand '{input}'. Please input something that begins with 'y' \
+                     or 'n', case insensitive:  "
+                );
+                bool_input(message, default)
+            },
+        }
+    } else {
+        Ok(default)
+    }
+}
+
 #[cfg(not(feature = "toml"))]
 fn main() {}

--- a/examples/upload_photo.rs
+++ b/examples/upload_photo.rs
@@ -4,29 +4,9 @@ mod register;
 use mastodon_async::{Result, StatusBuilder, Visibility};
 
 #[cfg(feature = "toml")]
-fn bool_input(message: impl AsRef<str>, default: bool) -> Result<bool> {
-    let input = register::read_line(message.as_ref())?;
-    if let Some(first_char) = input.chars().next() {
-        match first_char {
-            'Y' | 'y' => Ok(true),
-            'N' | 'n' => Ok(false),
-            '\n' => Ok(default),
-            _ => {
-                print!(
-                    "I didn't understand '{input}'. Please input something that begins with 'y' \
-                     or 'n', case insensitive:  "
-                );
-                bool_input(message, default)
-            },
-        }
-    } else {
-        Ok(default)
-    }
-}
-
-#[cfg(feature = "toml")]
 #[tokio::main]
 async fn main() -> Result<()> {
+    use register::bool_input;
     femme::with_level(femme::LevelFilter::Trace);
     let mastodon = register::get_mastodon_data().await?;
     let input = register::read_line("Enter the path to the photo you'd like to post: ")?;

--- a/src/entities/status.rs
+++ b/src/entities/status.rs
@@ -88,7 +88,11 @@ pub struct Emoji {
     pub url: String,
 }
 
-/// Hashtags in the status.
+/// Hashtags in the status. This functions both as a
+/// [`Status::Tag`](https://docs.joinmastodon.org/entities/Status/#Tag), and
+/// as a [`Tag`](https://docs.joinmastodon.org/entities/Tag/). In the case of
+/// the former, at the time of writing, the history field is always empty and
+/// the following field is always none.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Tag {
     /// The hashtag, not including the preceding `#`.
@@ -96,6 +100,7 @@ pub struct Tag {
     /// The URL of the hashtag.
     pub url: String,
     /// Usage statistics for given days (typically the past week).
+    #[serde(default = "Vec::new")]
     pub history: Vec<TagHistory>,
     /// Whether the current token’s authorized user is following this tag.
     pub following: Option<bool>,


### PR DESCRIPTION
Apparently, in some cases, the mastodon server responds with a [`Status::Tag`](https://docs.joinmastodon.org/entities/Status/#Tag) rather than a [`Tag`](https://docs.joinmastodon.org/entities/Tag/). This fixes that by defaulting the missing field in the former case, and adds an example status poster.