### PR TITLE
Add workflow job to build examples

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,6 +21,14 @@ jobs:
     - name: Run tests
       run: cargo test --verbose
 
+  build-examples:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build-examples
+      run: cargo build --examples --verbose
+
   clippy:
     needs: [build]
     runs-on: ubuntu-latest


### PR DESCRIPTION
Found that the examples are not build in the CI workflow... so here's a fix for that.