### PR TITLE
Add error variant for when not all bytes are written

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -64,6 +64,13 @@ pub enum Error {
     /// Error deserializing from toml
     #[error("Error deserializing from toml")]
     TomlDe(#[from] TomlDeError),
+
+    #[cfg(any(feature = "toml", feature = "json"))]
+    /// Error raised in the helpers::json::to_writer or helpers::toml::to_writer function if not
+    /// all bytes were written to the writer
+    #[error("Not all bytes were written")]
+    NotAllBytesWritten,
+
     /// Error converting an http header to a string
     #[error("Error converting an http header to a string")]
     HeaderStrError(#[from] HeaderStrError),

--- a/src/helpers/json.rs
+++ b/src/helpers/json.rs
@@ -48,8 +48,11 @@ pub fn to_vec(data: &Data) -> Result<Vec<u8>> {
 pub fn to_writer<W: Write>(data: &Data, writer: W) -> Result<()> {
     let mut buf_writer = BufWriter::new(writer);
     let vec = to_vec(data)?;
-    buf_writer.write(&vec)?;
-    Ok(())
+    if vec.len() != buf_writer.write(&vec)? {
+        Err(crate::Error::NotAllBytesWritten)
+    } else {
+        Ok(())
+    }
 }
 
 /// Attempts to serialize a Data struct to a file

--- a/src/helpers/json.rs
+++ b/src/helpers/json.rs
@@ -46,13 +46,7 @@ pub fn to_vec(data: &Data) -> Result<Vec<u8>> {
 /// Attempts to serialize a Data struct to something that implements the
 /// std::io::Write trait
 pub fn to_writer<W: Write>(data: &Data, writer: W) -> Result<()> {
-    let mut buf_writer = BufWriter::new(writer);
-    let vec = to_vec(data)?;
-    if vec.len() != buf_writer.write(&vec)? {
-        Err(crate::Error::NotAllBytesWritten)
-    } else {
-        Ok(())
-    }
+    Ok(serde_json::to_writer(data, writer)?)
 }
 
 /// Attempts to serialize a Data struct to a file

--- a/src/helpers/toml.rs
+++ b/src/helpers/toml.rs
@@ -48,7 +48,7 @@ pub fn to_vec(data: &Data) -> Result<Vec<u8>> {
 pub fn to_writer<W: Write>(data: &Data, writer: W) -> Result<()> {
     let mut buf_writer = BufWriter::new(writer);
     let vec = to_vec(data)?;
-    if vec.len() != !buf_writer.write(&vec)? {
+    if vec.len() != buf_writer.write(&vec)? {
         Err(crate::Error::NotAllBytesWritten)
     } else {
         Ok(())

--- a/src/helpers/toml.rs
+++ b/src/helpers/toml.rs
@@ -48,8 +48,11 @@ pub fn to_vec(data: &Data) -> Result<Vec<u8>> {
 pub fn to_writer<W: Write>(data: &Data, writer: W) -> Result<()> {
     let mut buf_writer = BufWriter::new(writer);
     let vec = to_vec(data)?;
-    buf_writer.write(&vec)?;
-    Ok(())
+    if vec.len() != !buf_writer.write(&vec)? {
+        Err(crate::Error::NotAllBytesWritten)
+    } else {
+        Ok(())
+    }
 }
 
 /// Attempts to serialize a Data struct to a file


### PR DESCRIPTION
cargo-clippy tells us that the `crate::helpers::json::to_writer` and `crate::helpers::toml::to_writer` functions were implemented without checking the return value of the `write()` function called inside.

That might lead to serious issues on the user site, if indeed not all bytes were written.

This patch fixes the issue of the user not knowning about the issue by introducing a new error variant and returning it in case of unfinished writes.

---

I found this because clippy is not enabled with `--all-features` in CI and I ran it with the flag. I have another patchset for fixing this issue as well, but I wanted to file this patch seperately because of discussion it might need.

---

The discussion I would want to raise here is whether this functionality is actually needed. The helper functions are literally four lines that every user of the library should be able to implement on their own (with better error handling, if they implement it themselves).

For us, these helper functions provide a bit of value, so I wouldn't remove them but make them private. If we decide on doing this, we might want to add this to a list of breaking changes for future release (not sure whether there is already such a thing).