### PR TITLE
Make Registered::complete() accept an AsRef<str>

### DIFF
--- a/src/registration.rs
+++ b/src/registration.rs
@@ -336,11 +336,15 @@ impl Registered {
 
     /// Create an access token from the client id, client secret, and code
     /// provided by the authorization url.
-    pub async fn complete(&self, code: &str) -> Result<Mastodon> {
-        let url = format!(
+    pub async fn complete<C>(&self, code: C) -> Result<Mastodon>
+    where
+        C: AsRef<str>,
+    {
+        let url =
+            format!(
             "{}/oauth/token?client_id={}&client_secret={}&code={}&grant_type=authorization_code&\
              redirect_uri={}",
-            self.base, self.client_id, self.client_secret, code, self.redirect
+            self.base, self.client_id, self.client_secret, code.as_ref(), self.redirect
         );
         debug!(url = url; "completing registration");
         let response = self.client.post(&url).send().await?;


### PR DESCRIPTION
This patch changes the signature of `Registered::complete` to accept an `AsRef<str>`. This _should_ be backwards compatible to the old version.

This change was implemented as it has the neat benefit that a user can implement a type that does not implement `Debug` or `Display`, but only `AsRef<str>`.
This can be done to ensure that the access code is not accidentally shown in log output, which might be pasted to some code forge for bug reporting.


---

What do you think?