### PR TITLE
Drop unnecessary tokio feature dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ optional = true
 
 [dependencies.tokio]
 version = "1.22.0"
-features = ["rt-multi-thread", "macros"]
+features = ["macros"]
 
 [dependencies.tokio-util]
 version = "0.7.4"


### PR DESCRIPTION
Should resolve #38, though #39 still seems prudent.

Please test that this actually builds for WASM in your Tauri project @matthiasbeyer 