### PR TITLE
Add "poll" notification support

### DIFF
--- a/entities/src/notification.rs
+++ b/entities/src/notification.rs
@@ -34,4 +34,6 @@ pub enum NotificationType {
     Favourite,
     /// Someone followed the application client.
     Follow,
+    /// A poll the application client previously voted in has ended.
+    Poll,
 }

--- a/entities/src/notification.rs
+++ b/entities/src/notification.rs
@@ -34,6 +34,9 @@ pub enum NotificationType {
     Favourite,
     /// Someone followed the application client.
     Follow,
+    /// Someone asked to followed the application client when follow requests must be approved.
+    #[serde(rename = "follow_request")]
+    FollowRequest,
     /// A poll the application client previously voted in has ended.
     Poll,
 }


### PR DESCRIPTION
Closes #48 

This is the minimal patch needed to avoid the issue. I was expecting to parse the poll data, but that seems to be hidden behind a "..." in the notification content itself by the API.

I would have also added tests, but this is trivial and I couldn't figure out where.