### PR TITLE
Registration::new_with_client

### DIFF
--- a/src/registration.rs
+++ b/src/registration.rs
@@ -58,7 +58,8 @@ impl<'a> Registration<'a> {
     /// ```
     /// use mastodon_async::prelude::*;
     ///
-    /// let registration = Registration::new("https://botsin.space");
+    /// let client = reqwest::Client::builder().user_agent("my cool app").build().unwrap();
+    /// let registration = Registration::new_with_client("https://botsin.space", client);
     /// ```
     pub fn new_with_client<I: Into<String>>(base: I, client: Client) -> Self {
         Registration {

--- a/src/registration.rs
+++ b/src/registration.rs
@@ -57,6 +57,22 @@ impl<'a> Registration<'a> {
             force_login: false,
         }
     }
+
+    /// Construct a new registration process to the instance of the `base` url,
+    /// using the provided [Client].
+    /// ```
+    /// use mastodon_async::prelude::*;
+    ///
+    /// let registration = Registration::new("https://botsin.space");
+    /// ```
+    pub fn new_with_client<I: Into<String>>(base: I, client: Client) -> Self {
+        Registration {
+            base: base.into(),
+            client,
+            app_builder: AppBuilder::new(),
+            force_login: false,
+        }
+    }
 }
 
 impl<'a> Registration<'a> {

--- a/src/registration.rs
+++ b/src/registration.rs
@@ -50,12 +50,7 @@ impl<'a> Registration<'a> {
     /// let registration = Registration::new("https://botsin.space");
     /// ```
     pub fn new<I: Into<String>>(base: I) -> Self {
-        Registration {
-            base: base.into(),
-            client: Client::new(),
-            app_builder: AppBuilder::new(),
-            force_login: false,
-        }
+        Registration::new_with_client(base, Client::new())
     }
 
     /// Construct a new registration process to the instance of the `base` url,


### PR DESCRIPTION
`Registration` can now be created with a custom Reqwest `Client`. This makes it possible to set a user agent (required for gotosocial), and provides symmetry with `Mastodon::new` that takes a `Client` argument.