### PR TITLE
Instance api

### DIFF
--- a/entities/src/account.rs
+++ b/entities/src/account.rs
@@ -81,6 +81,7 @@ static_assertions::assert_not_impl_any!(
     PartialEq<crate::push::SubscriptionId>,
     PartialEq<crate::report::ReportId>,
     PartialEq<crate::status::StatusId>,
+    PartialEq<crate::instance::RuleId>,
 );
 
 /// A single name: value pair from a user's profile

--- a/entities/src/attachment.rs
+++ b/entities/src/attachment.rs
@@ -51,6 +51,7 @@ static_assertions::assert_not_impl_any!(
     PartialEq<crate::report::ReportId>,
     PartialEq<crate::push::SubscriptionId>,
     PartialEq<crate::status::StatusId>,
+    PartialEq<crate::instance::RuleId>,
 );
 
 /// Information about the attachment itself.

--- a/entities/src/conversion.rs
+++ b/entities/src/conversion.rs
@@ -1,0 +1,39 @@
+pub(crate) mod string_to_u64 {
+    use serde::{
+        de::{self, Visitor},
+        Deserializer, Serializer,
+    };
+
+    pub(crate) fn serialize<S>(value: &u64, ser: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        ser.serialize_str(&value.to_string())
+    }
+
+    pub(crate) fn deserialize<'de, D>(deserializer: D) -> Result<u64, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct StringToIntVisitor;
+
+        impl<'v> Visitor<'v> for StringToIntVisitor {
+            type Value = u64;
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                write!(
+                    formatter,
+                    "a string which can be parsed as an unsigned, 64-bit integer"
+                )
+            }
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                v.parse()
+                    .map_err(|_| de::Error::invalid_value(de::Unexpected::Str(v), &self))
+            }
+        }
+
+        deserializer.deserialize_str(StringToIntVisitor)
+    }
+}

--- a/entities/src/filter.rs
+++ b/entities/src/filter.rs
@@ -78,6 +78,7 @@ static_assertions::assert_not_impl_any!(
     PartialEq<crate::push::SubscriptionId>,
     PartialEq<crate::report::ReportId>,
     PartialEq<crate::status::StatusId>,
+    PartialEq<crate::instance::RuleId>,
 );
 
 /// Represents the various types of Filter contexts

--- a/entities/src/instance.rs
+++ b/entities/src/instance.rs
@@ -46,7 +46,7 @@ pub struct Stats {
     domain_count: u64,
 }
 
-/// Statistics about the Mastodon instance.
+/// Rules of an instance
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct Rule {
     /// An identifier for the rule.
@@ -55,7 +55,7 @@ pub struct Rule {
     pub text: String,
 }
 
-/// A struct containing info of an instance-level domain block.
+/// An instance-level domain block.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct DomainBlock {
     /// URI of the domain in question

--- a/entities/src/instance.rs
+++ b/entities/src/instance.rs
@@ -50,10 +50,39 @@ pub struct Stats {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct Rule {
     /// An identifier for the rule.
-    pub id: String,
+    pub id: RuleId,
     /// The rule to be followed.
     pub text: String,
 }
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(transparent)]
+pub struct RuleId(String);
+
+impl AsRef<str> for RuleId {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl RuleId {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+}
+
+static_assertions::assert_not_impl_any!(
+    RuleId: PartialEq<crate::account::AccountId>,
+    PartialEq<crate::attachment::AttachmentId>,
+    PartialEq<crate::list::ListId>,
+    PartialEq<crate::mention::MentionId>,
+    PartialEq<crate::notification::NotificationId>,
+    PartialEq<crate::relationship::RelationshipId>,
+    PartialEq<crate::push::SubscriptionId>,
+    PartialEq<crate::report::ReportId>,
+    PartialEq<crate::status::StatusId>,
+    PartialEq<crate::filter::FilterId>,
+);
 
 /// An instance-level domain block.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]

--- a/entities/src/instance.rs
+++ b/entities/src/instance.rs
@@ -45,3 +45,12 @@ pub struct Stats {
     status_count: u64,
     domain_count: u64,
 }
+
+/// Statistics about the Mastodon instance.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct Rule {
+    /// An identifier for the rule.
+    pub id: String,
+    /// The rule to be followed.
+    pub text: String,
+}

--- a/entities/src/instance.rs
+++ b/entities/src/instance.rs
@@ -67,3 +67,12 @@ pub struct DomainBlock {
     /// Admin's public comment.
     pub comment: String,
 }
+
+/// Weekly activity on an instance
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct Activity {
+    pub week: String,
+    pub statuses: String,
+    pub logins: String,
+    pub registrations: String,
+}

--- a/entities/src/instance.rs
+++ b/entities/src/instance.rs
@@ -1,7 +1,7 @@
 //! Module containing everything related to an instance.
 use serde::{Deserialize, Serialize};
 
-use super::account::Account;
+use crate::{account::Account, conversion};
 
 /// A struct containing info of an instance.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
@@ -74,9 +74,12 @@ pub struct Activity {
     /// UNIX Timestamp at midnight at the first day of the week.
     pub week: String,
     /// The number of Statuses created since the week began (cast from an integer)
-    pub statuses: String,
+    #[serde(with = "conversion::string_to_u64")]
+    pub statuses: u64,
     /// The number of user logins since the week began (cast from an integer)
-    pub logins: String,
+    #[serde(with = "conversion::string_to_u64")]
+    pub logins: u64,
     /// The number of user registrations since the week began (cast from an integer)
-    pub registrations: String,
+    #[serde(with = "conversion::string_to_u64")]
+    pub registrations: u64,
 }

--- a/entities/src/instance.rs
+++ b/entities/src/instance.rs
@@ -71,8 +71,12 @@ pub struct DomainBlock {
 /// Weekly activity on an instance
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct Activity {
+    /// UNIX Timestamp at midnight at the first day of the week.
     pub week: String,
+    /// The number of Statuses created since the week began (cast from an integer)
     pub statuses: String,
+    /// The number of user logins since the week began (cast from an integer)
     pub logins: String,
+    /// The number of user registrations since the week began (cast from an integer)
     pub registrations: String,
 }

--- a/entities/src/instance.rs
+++ b/entities/src/instance.rs
@@ -54,3 +54,16 @@ pub struct Rule {
     /// The rule to be followed.
     pub text: String,
 }
+
+/// A struct containing info of an instance-level domain block.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct DomainBlock {
+    /// URI of the domain in question
+    pub domain: String,
+    /// Digest
+    pub digest: String,
+    /// Severity of the block
+    pub severity: String,
+    /// Admin's public comment.
+    pub comment: String,
+}

--- a/entities/src/lib.rs
+++ b/entities/src/lib.rs
@@ -12,6 +12,8 @@ pub mod attachment;
 pub mod card;
 /// Data structures for ser/de of contetx-related resources
 pub mod context;
+/// Module for converting values while serializing and deserializing.
+mod conversion;
 /// Data structures for ser/de of streaming events
 pub mod event;
 /// Data structures for ser/de of filter-related resources

--- a/entities/src/list.rs
+++ b/entities/src/list.rs
@@ -34,4 +34,5 @@ static_assertions::assert_not_impl_any!(
     PartialEq<crate::relationship::RelationshipId>,
     PartialEq<crate::report::ReportId>,
     PartialEq<crate::status::StatusId>,
+    PartialEq<crate::instance::RuleId>,
 );

--- a/entities/src/mention.rs
+++ b/entities/src/mention.rs
@@ -40,4 +40,5 @@ static_assertions::assert_not_impl_any!(
     PartialEq<crate::push::SubscriptionId>,
     PartialEq<crate::report::ReportId>,
     PartialEq<crate::status::StatusId>,
+    PartialEq<crate::instance::RuleId>,
 );

--- a/entities/src/notification.rs
+++ b/entities/src/notification.rs
@@ -49,6 +49,7 @@ static_assertions::assert_not_impl_any!(
     PartialEq<crate::relationship::RelationshipId>,
     PartialEq<crate::report::ReportId>,
     PartialEq<crate::status::StatusId>,
+    PartialEq<crate::instance::RuleId>,
 );
 
 /// The type of notification.

--- a/entities/src/push.rs
+++ b/entities/src/push.rs
@@ -52,6 +52,7 @@ static_assertions::assert_not_impl_any!(
     PartialEq<crate::relationship::RelationshipId>,
     PartialEq<crate::report::ReportId>,
     PartialEq<crate::status::StatusId>,
+    PartialEq<crate::instance::RuleId>,
 );
 
 pub mod add_subscription {

--- a/entities/src/relationship.rs
+++ b/entities/src/relationship.rs
@@ -59,4 +59,5 @@ static_assertions::assert_not_impl_any!(
     PartialEq<crate::list::ListId>,
     PartialEq<crate::report::ReportId>,
     PartialEq<crate::status::StatusId>,
+    PartialEq<crate::instance::RuleId>,
 );

--- a/entities/src/report.rs
+++ b/entities/src/report.rs
@@ -38,4 +38,5 @@ static_assertions::assert_not_impl_any!(
     PartialEq<crate::relationship::RelationshipId>,
     PartialEq<crate::list::ListId>,
     PartialEq<crate::status::StatusId>,
+    PartialEq<crate::instance::RuleId>,
 );

--- a/entities/src/status.rs
+++ b/entities/src/status.rs
@@ -92,6 +92,7 @@ static_assertions::assert_not_impl_any!(
     PartialEq<crate::relationship::RelationshipId>,
     PartialEq<crate::report::ReportId>,
     PartialEq<crate::list::ListId>,
+    PartialEq<crate::instance::RuleId>,
 );
 
 /// A mention of another user.

--- a/examples/show_instance_peers.rs
+++ b/examples/show_instance_peers.rs
@@ -1,0 +1,59 @@
+#![cfg_attr(not(feature = "toml"), allow(dead_code))]
+#![cfg_attr(not(feature = "toml"), allow(unused_imports))]
+mod register;
+
+use futures_util::StreamExt;
+use mastodon_async::Result;
+use std::{
+    io::Write,
+    process::{exit, Command, Stdio},
+};
+
+#[cfg(feature = "toml")]
+async fn run() -> Result<()> {
+    use register::bool_input;
+    let mastodon = register::get_mastodon_data().await?;
+
+    let peers: Vec<_> = mastodon
+        .instance_peers()
+        .await?
+        .items_iter()
+        .collect()
+        .await;
+
+    if bool_input(format!("print {} peers?", peers.len()), false)? {
+        let mut process = Command::new("less")
+            .stdout(Stdio::inherit())
+            .stdin(Stdio::piped())
+            .spawn()?;
+        let mut pipe = process.stdin.take().unwrap();
+        for peer in peers {
+            pipe.write_all(peer.as_bytes())?;
+            pipe.write_all(&[10])?
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(all(feature = "toml", feature = "mt"))]
+#[tokio::main]
+async fn main() -> Result<()> {
+    run().await
+}
+
+#[cfg(all(feature = "toml", not(feature = "mt")))]
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
+    run().await
+}
+
+#[cfg(not(feature = "toml"))]
+fn main() {
+    use std::process::Stdio;
+
+    println!(
+        "examples require the `toml` feature, run this command for this example:\n\ncargo run \
+         --example show_instance_peers --features toml\n"
+    );
+}

--- a/src/mastodon.rs
+++ b/src/mastodon.rs
@@ -61,6 +61,7 @@ impl Mastodon {
         (get) get_emojis: "custom_emojis" => Emoji,
         (get) mutes: "mutes" => Account,
         (get) notifications: "notifications" => Notification,
+        (get) instance_peers: "instance/peers" => String,
         (get) reports: "reports" => Report,
         (get (q: &'a str, #[serde(skip_serializing_if = "Option::is_none")] limit: Option<u64>, following: bool,)) search_accounts: "accounts/search" => Account,
         (get) get_endorsements: "endorsements" => Account,

--- a/src/mastodon.rs
+++ b/src/mastodon.rs
@@ -17,9 +17,9 @@ use crate::{
 use futures::TryStream;
 use log::{as_debug, as_serde, debug, error, trace};
 use reqwest::{multipart::Part, Client, RequestBuilder};
+use std::collections::HashMap;
 use url::Url;
 use uuid::Uuid;
-use std::collections::HashMap;
 
 /// The Mastodon client is a smart pointer to this struct
 #[derive(Debug)]
@@ -64,6 +64,7 @@ impl Mastodon {
         (get) notifications: "notifications" => Notification,
         (get) instance_peers: "instance/peers" => String,
         (get) instance_activity: "instance/activity" => HashMap<String, String>,
+        (get) instance_rules: "instance/rules" => Rule,
         (get) reports: "reports" => Report,
         (get (q: &'a str, #[serde(skip_serializing_if = "Option::is_none")] limit: Option<u64>, following: bool,)) search_accounts: "accounts/search" => Account,
         (get) get_endorsements: "endorsements" => Account,

--- a/src/mastodon.rs
+++ b/src/mastodon.rs
@@ -19,6 +19,7 @@ use log::{as_debug, as_serde, debug, error, trace};
 use reqwest::{multipart::Part, Client, RequestBuilder};
 use url::Url;
 use uuid::Uuid;
+use std::collections::HashMap;
 
 /// The Mastodon client is a smart pointer to this struct
 #[derive(Debug)]
@@ -62,6 +63,7 @@ impl Mastodon {
         (get) mutes: "mutes" => Account,
         (get) notifications: "notifications" => Notification,
         (get) instance_peers: "instance/peers" => String,
+        (get) instance_activity: "instance/activity" => HashMap<String, String>,
         (get) reports: "reports" => Report,
         (get (q: &'a str, #[serde(skip_serializing_if = "Option::is_none")] limit: Option<u64>, following: bool,)) search_accounts: "accounts/search" => Account,
         (get) get_endorsements: "endorsements" => Account,

--- a/src/mastodon.rs
+++ b/src/mastodon.rs
@@ -17,7 +17,6 @@ use crate::{
 use futures::TryStream;
 use log::{as_debug, as_serde, debug, error, trace};
 use reqwest::{multipart::Part, Client, RequestBuilder};
-use std::collections::HashMap;
 use url::Url;
 use uuid::Uuid;
 
@@ -64,7 +63,7 @@ impl Mastodon {
         (get) mutes: "mutes" => Account,
         (get) notifications: "notifications" => Notification,
         (get) instance_peers: "instance/peers" => String,
-        (get) instance_activity: "instance/activity" => HashMap<String, String>,
+        (get) instance_activity: "instance/activity" => Activity,
         (get) instance_rules: "instance/rules" => Rule,
         (get) reports: "reports" => Report,
         (get (q: &'a str, #[serde(skip_serializing_if = "Option::is_none")] limit: Option<u64>, following: bool,)) search_accounts: "accounts/search" => Account,

--- a/src/mastodon.rs
+++ b/src/mastodon.rs
@@ -57,6 +57,7 @@ impl Mastodon {
         (get) favourites: "favourites" => Status,
         (get) blocks: "blocks" => Account,
         (get) domain_blocks: "domain_blocks" => String,
+        (get) instance_domain_blocks: "instance/domain_blocks" => DomainBlock,
         (get) follow_requests: "follow_requests" => Account,
         (get) get_home_timeline: "timelines/home" => Status,
         (get) get_emojis: "custom_emojis" => Emoji,


### PR DESCRIPTION
Implemented from [instance API methods](https://docs.joinmastodon.org/methods/instance/):

* `GET /api/v1/instance/peers`
* `GET /api/v1/instance/rules`
* `GET /api/v1/instance/activity`

Not yet implemented:

* `GET /api/v1/instance/domain_blocks`
* `GET /api/v1/example`

I have an maybe-working implementation lying around but as I don't have access to a 4.0.0+ Mastodon instance, and it looks like GoToSocial doesn't implement it either, I couldn't test these two.