### PR TITLE
Use macro to define ID types

### DIFF
--- a/entities/src/account.rs
+++ b/entities/src/account.rs
@@ -4,8 +4,10 @@ use serde::{
     de::{self, Deserializer, Unexpected},
     Deserialize, Serialize,
 };
-use std::{fmt::Display, path::PathBuf};
+use std::path::PathBuf;
 use time::{serde::iso8601, OffsetDateTime};
+
+use crate::AccountId;
 
 /// A struct representing an Account.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
@@ -53,41 +55,6 @@ pub struct Account {
     /// Boolean indicating whether this account is a bot or not
     pub bot: Option<bool>,
 }
-
-/// Wrapper type for a account ID string
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(transparent)]
-pub struct AccountId(String);
-
-impl AsRef<str> for AccountId {
-    fn as_ref(&self) -> &str {
-        &self.0
-    }
-}
-
-impl AccountId {
-    pub fn new(value: impl Into<String>) -> Self {
-        Self(value.into())
-    }
-}
-
-impl Display for AccountId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-static_assertions::assert_not_impl_any!(
-    AccountId: PartialEq<crate::attachment::AttachmentId>,
-    PartialEq<crate::filter::FilterId>,
-    PartialEq<crate::list::ListId>,
-    PartialEq<crate::mention::MentionId>,
-    PartialEq<crate::notification::NotificationId>,
-    PartialEq<crate::relationship::RelationshipId>,
-    PartialEq<crate::push::SubscriptionId>,
-    PartialEq<crate::report::ReportId>,
-    PartialEq<crate::status::StatusId>,
-);
 
 /// A single name: value pair from a user's profile
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]

--- a/entities/src/attachment.rs
+++ b/entities/src/attachment.rs
@@ -1,7 +1,6 @@
 //! Module containing everything related to media attachements.
 
-use std::fmt::Display;
-
+use crate::AttachmentId;
 use serde::{Deserialize, Serialize};
 
 /// A struct representing a media attachment.
@@ -39,40 +38,6 @@ impl Attachment {
         self.url.is_some()
     }
 }
-/// Wrapper type for a attachment ID string
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(transparent)]
-pub struct AttachmentId(String);
-
-impl AsRef<str> for AttachmentId {
-    fn as_ref(&self) -> &str {
-        &self.0
-    }
-}
-
-impl AttachmentId {
-    pub fn new(value: impl Into<String>) -> Self {
-        Self(value.into())
-    }
-}
-
-impl Display for AttachmentId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-static_assertions::assert_not_impl_any!(
-    AttachmentId: PartialEq<crate::account::AccountId>,
-    PartialEq<crate::filter::FilterId>,
-    PartialEq<crate::list::ListId>,
-    PartialEq<crate::mention::MentionId>,
-    PartialEq<crate::notification::NotificationId>,
-    PartialEq<crate::relationship::RelationshipId>,
-    PartialEq<crate::report::ReportId>,
-    PartialEq<crate::push::SubscriptionId>,
-    PartialEq<crate::status::StatusId>,
-);
 
 /// Information about the attachment itself.
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]

--- a/entities/src/filter.rs
+++ b/entities/src/filter.rs
@@ -1,7 +1,7 @@
-use std::fmt::Display;
-
 use serde::{de::Visitor, Deserialize, Deserializer, Serialize};
 use time::{serde::iso8601, OffsetDateTime};
+
+use crate::FilterId;
 
 /// Represents a user-defined filter for determining which statuses should not
 /// be shown to the user.
@@ -52,41 +52,6 @@ pub struct Filter {
     /// The statuses grouped under this filter.
     pub statuses: Vec<Status>,
 }
-
-/// Wrapper type for a filter ID string
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(transparent)]
-pub struct FilterId(String);
-
-impl AsRef<str> for FilterId {
-    fn as_ref(&self) -> &str {
-        &self.0
-    }
-}
-
-impl FilterId {
-    pub fn new(value: impl Into<String>) -> Self {
-        Self(value.into())
-    }
-}
-
-impl Display for FilterId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-static_assertions::assert_not_impl_any!(
-    FilterId: PartialEq<crate::account::AccountId>,
-    PartialEq<crate::attachment::AttachmentId>,
-    PartialEq<crate::list::ListId>,
-    PartialEq<crate::mention::MentionId>,
-    PartialEq<crate::notification::NotificationId>,
-    PartialEq<crate::relationship::RelationshipId>,
-    PartialEq<crate::push::SubscriptionId>,
-    PartialEq<crate::report::ReportId>,
-    PartialEq<crate::status::StatusId>,
-);
 
 /// Represents the various types of Filter contexts
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/entities/src/ids.rs
+++ b/entities/src/ids.rs
@@ -1,0 +1,50 @@
+use serde::{Deserialize, Serialize};
+use std::fmt::Display;
+
+macro_rules! define_ids {
+    ($name:ident, $($rest:ident,)+) => {
+        define_ids!($name,);
+        static_assertions::assert_not_impl_any!(
+            $name: $(PartialEq<$rest>,)+
+        );
+        define_ids!($($rest,)+);
+    };
+    ($name:ident,) => {
+        /// Wrapper type for a account ID string
+        #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+        #[serde(transparent)]
+        pub struct $name(String);
+
+        impl AsRef<str> for $name {
+            fn as_ref(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl $name {
+            pub fn new(value: impl Into<String>) -> Self {
+                Self(value.into())
+            }
+        }
+
+        impl Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "{}", self.0)
+            }
+        }
+    };
+    () => {}
+}
+
+define_ids!(
+    AccountId,
+    AttachmentId,
+    FilterId,
+    ListId,
+    MentionId,
+    NotificationId,
+    SubscriptionId,
+    RelationshipId,
+    ReportId,
+    StatusId,
+);

--- a/entities/src/lib.rs
+++ b/entities/src/lib.rs
@@ -16,6 +16,9 @@ pub mod context;
 pub mod event;
 /// Data structures for ser/de of filter-related resources
 pub mod filter;
+/// Type-safe ID values
+pub mod ids;
+pub use ids::*;
 /// Data structures for ser/de of instance-related resources
 pub mod instance;
 /// Data structures for ser/de of list-related resources
@@ -46,21 +49,23 @@ pub struct Empty {}
 /// modules:
 pub mod prelude {
     pub use super::{
-        account::{Account, AccountId, Source},
-        attachment::{Attachment, AttachmentId, MediaType},
+        account::{Account, Source},
+        attachment::{Attachment, MediaType},
         card::Card,
         context::Context,
         event::Event,
-        filter::{Filter, FilterContext, FilterId},
+        filter::{Filter, FilterContext},
+        ids::*,
         instance::*,
-        list::{List, ListId},
-        mention::{Mention, MentionId},
-        notification::{Notification, NotificationId},
-        push::{Subscription, SubscriptionId},
-        relationship::{Relationship, RelationshipId},
-        report::{Report, ReportId},
+        list::List,
+        mention::Mention,
+        notification::Notification,
+        push::Subscription,
+        relationship::Relationship,
+        report::Report,
         search_result::SearchResult,
-        status::{Application, Emoji, Status, StatusId},
+        status::{Application, Emoji, Status},
+        visibility::Visibility,
         Empty,
     };
 }

--- a/entities/src/list.rs
+++ b/entities/src/list.rs
@@ -1,37 +1,10 @@
 use serde::{Deserialize, Serialize};
 
+use crate::ListId;
+
 /// Used for ser/de of list resources
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct List {
     id: ListId,
     title: String,
 }
-
-/// Wrapper type for a list ID string
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(transparent)]
-pub struct ListId(String);
-
-impl AsRef<str> for ListId {
-    fn as_ref(&self) -> &str {
-        &self.0
-    }
-}
-
-impl ListId {
-    pub fn new(value: impl Into<String>) -> Self {
-        Self(value.into())
-    }
-}
-
-static_assertions::assert_not_impl_any!(
-    ListId: PartialEq<crate::account::AccountId>,
-    PartialEq<crate::attachment::AttachmentId>,
-    PartialEq<crate::filter::FilterId>,
-    PartialEq<crate::push::SubscriptionId>,
-    PartialEq<crate::mention::MentionId>,
-    PartialEq<crate::notification::NotificationId>,
-    PartialEq<crate::relationship::RelationshipId>,
-    PartialEq<crate::report::ReportId>,
-    PartialEq<crate::status::StatusId>,
-);

--- a/entities/src/mention.rs
+++ b/entities/src/mention.rs
@@ -1,5 +1,3 @@
-use std::fmt::Display;
-
 use serde::{Deserialize, Serialize};
 
 /// Represents a `mention` used in a status
@@ -14,38 +12,3 @@ pub struct Mention {
     /// Account ID
     pub id: String,
 }
-
-/// Wrapper type for a mention ID string
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(transparent)]
-pub struct MentionId(String);
-
-impl AsRef<str> for MentionId {
-    fn as_ref(&self) -> &str {
-        &self.0
-    }
-}
-
-impl MentionId {
-    pub fn new(value: impl Into<String>) -> Self {
-        Self(value.into())
-    }
-}
-
-impl Display for MentionId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-static_assertions::assert_not_impl_any!(
-    Mention: PartialEq<crate::account::AccountId>,
-    PartialEq<crate::attachment::AttachmentId>,
-    PartialEq<crate::filter::FilterId>,
-    PartialEq<crate::list::ListId>,
-    PartialEq<crate::notification::NotificationId>,
-    PartialEq<crate::relationship::RelationshipId>,
-    PartialEq<crate::push::SubscriptionId>,
-    PartialEq<crate::report::ReportId>,
-    PartialEq<crate::status::StatusId>,
-);

--- a/entities/src/notification.rs
+++ b/entities/src/notification.rs
@@ -1,6 +1,6 @@
 //! Module containing all info about notifications.
 
-use std::fmt::Display;
+use crate::NotificationId;
 
 use super::{account::Account, status::Status};
 use serde::{Deserialize, Serialize};
@@ -23,41 +23,6 @@ pub struct Notification {
     /// The Status associated with the notification, if applicable.
     pub status: Option<Status>,
 }
-
-/// Wrapper type for a notification ID string
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(transparent)]
-pub struct NotificationId(String);
-
-impl AsRef<str> for NotificationId {
-    fn as_ref(&self) -> &str {
-        &self.0
-    }
-}
-
-impl NotificationId {
-    pub fn new(value: impl Into<String>) -> Self {
-        Self(value.into())
-    }
-}
-
-impl Display for NotificationId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-static_assertions::assert_not_impl_any!(
-    NotificationId: PartialEq<crate::account::AccountId>,
-    PartialEq<crate::attachment::AttachmentId>,
-    PartialEq<crate::filter::FilterId>,
-    PartialEq<crate::mention::MentionId>,
-    PartialEq<crate::list::ListId>,
-    PartialEq<crate::push::SubscriptionId>,
-    PartialEq<crate::relationship::RelationshipId>,
-    PartialEq<crate::report::ReportId>,
-    PartialEq<crate::status::StatusId>,
-);
 
 /// The type of notification.
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]

--- a/entities/src/push.rs
+++ b/entities/src/push.rs
@@ -1,6 +1,6 @@
-use std::fmt::Display;
-
 use serde::{Deserialize, Serialize};
+
+use crate::SubscriptionId;
 
 /// Represents the `alerts` key of the `Subscription` object
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -27,40 +27,6 @@ pub struct Subscription {
     /// The status of the alerts for this subscription
     pub alerts: Option<Alerts>,
 }
-
-/// Wrapper type for a subscription ID string
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(transparent)]
-pub struct SubscriptionId(String);
-
-impl AsRef<str> for SubscriptionId {
-    fn as_ref(&self) -> &str {
-        &self.0
-    }
-}
-
-impl SubscriptionId {
-    pub fn new(value: impl Into<String>) -> Self {
-        Self(value.into())
-    }
-}
-
-impl Display for SubscriptionId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-static_assertions::assert_not_impl_any!(
-    SubscriptionId: PartialEq<crate::account::AccountId>,
-    PartialEq<crate::attachment::AttachmentId>,
-    PartialEq<crate::filter::FilterId>,
-    PartialEq<crate::mention::MentionId>,
-    PartialEq<crate::notification::NotificationId>,
-    PartialEq<crate::relationship::RelationshipId>,
-    PartialEq<crate::report::ReportId>,
-    PartialEq<crate::status::StatusId>,
-);
 
 pub mod add_subscription {
     use serde::Serialize;

--- a/entities/src/relationship.rs
+++ b/entities/src/relationship.rs
@@ -1,9 +1,8 @@
 //! module containing everything relating to a relationship with
 //! another account.
-
-use std::fmt::Display;
-
 use serde::{Deserialize, Serialize};
+
+use crate::RelationshipId;
 
 /// A struct containing information about a relationship with another account.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -33,37 +32,3 @@ pub struct Relationship {
     /// making calls to pleroma or mastodon<2.5.0 instances
     pub endorsed: Option<bool>,
 }
-
-/// Wrapper type for a relationship ID string
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(transparent)]
-pub struct RelationshipId(String);
-
-impl AsRef<str> for RelationshipId {
-    fn as_ref(&self) -> &str {
-        &self.0
-    }
-}
-
-impl RelationshipId {
-    pub fn new(value: impl Into<String>) -> Self {
-        Self(value.into())
-    }
-}
-impl Display for RelationshipId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-static_assertions::assert_not_impl_any!(
-    RelationshipId: PartialEq<crate::account::AccountId>,
-    PartialEq<crate::attachment::AttachmentId>,
-    PartialEq<crate::filter::FilterId>,
-    PartialEq<crate::push::SubscriptionId>,
-    PartialEq<crate::mention::MentionId>,
-    PartialEq<crate::notification::NotificationId>,
-    PartialEq<crate::list::ListId>,
-    PartialEq<crate::report::ReportId>,
-    PartialEq<crate::status::StatusId>,
-);

--- a/entities/src/report.rs
+++ b/entities/src/report.rs
@@ -1,8 +1,7 @@
 //! module containing information about a finished report of a user.
-
-use std::fmt::Display;
-
 use serde::{Deserialize, Serialize};
+
+use crate::ReportId;
 
 /// A struct containing info about a report.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -12,38 +11,3 @@ pub struct Report {
     /// The action taken in response to the report.
     pub action_taken: String,
 }
-
-/// Wrapper type for a report ID string
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(transparent)]
-pub struct ReportId(String);
-
-impl AsRef<str> for ReportId {
-    fn as_ref(&self) -> &str {
-        &self.0
-    }
-}
-
-impl ReportId {
-    pub fn new(value: impl Into<String>) -> Self {
-        Self(value.into())
-    }
-}
-
-impl Display for ReportId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-static_assertions::assert_not_impl_any!(
-    ReportId: PartialEq<crate::account::AccountId>,
-    PartialEq<crate::attachment::AttachmentId>,
-    PartialEq<crate::filter::FilterId>,
-    PartialEq<crate::push::SubscriptionId>,
-    PartialEq<crate::mention::MentionId>,
-    PartialEq<crate::notification::NotificationId>,
-    PartialEq<crate::relationship::RelationshipId>,
-    PartialEq<crate::list::ListId>,
-    PartialEq<crate::status::StatusId>,
-);

--- a/entities/src/status.rs
+++ b/entities/src/status.rs
@@ -1,9 +1,6 @@
 //! Module containing all info relating to a status.
 
-use std::fmt::Display;
-
 use super::prelude::*;
-use crate::{card::Card, visibility::Visibility};
 use serde::{Deserialize, Serialize};
 use time::{serde::iso8601, OffsetDateTime};
 
@@ -66,41 +63,6 @@ pub struct Status {
     /// Whether this is the pinned status for the account that posted it.
     pub pinned: Option<bool>,
 }
-
-/// Wrapper type for a status ID string
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(transparent)]
-pub struct StatusId(String);
-
-impl AsRef<str> for StatusId {
-    fn as_ref(&self) -> &str {
-        &self.0
-    }
-}
-
-impl StatusId {
-    pub fn new(value: impl Into<String>) -> Self {
-        Self(value.into())
-    }
-}
-
-impl Display for StatusId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-static_assertions::assert_not_impl_any!(
-    StatusId: PartialEq<crate::account::AccountId>,
-    PartialEq<crate::attachment::AttachmentId>,
-    PartialEq<crate::filter::FilterId>,
-    PartialEq<crate::push::SubscriptionId>,
-    PartialEq<crate::mention::MentionId>,
-    PartialEq<crate::notification::NotificationId>,
-    PartialEq<crate::relationship::RelationshipId>,
-    PartialEq<crate::report::ReportId>,
-    PartialEq<crate::list::ListId>,
-);
 
 /// A mention of another user.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/examples/follow_profile.rs
+++ b/examples/follow_profile.rs
@@ -5,7 +5,7 @@ use mastodon_async::Result;
 
 #[cfg(feature = "toml")]
 async fn run() -> Result<()> {
-    use mastodon_async::entities::account::AccountId;
+    use mastodon_async::entities::AccountId;
     let mastodon = register::get_mastodon_data().await?;
     let input = register::read_line("Enter the account id you'd like to follow: ")?;
     let account = AccountId::new(input.trim());


### PR DESCRIPTION
I was working on #64 and was about to define yet *another* ID type when I decided enough was enough, this needs to be declared in a macro. So, here it is. Same functionality, slightly different namespacing, declared as a simple list of ID types in `entities/src/ids.rs`