### PR TITLE
Pass client instance to the event stream

### DIFF
--- a/examples/log_events.rs
+++ b/examples/log_events.rs
@@ -15,7 +15,7 @@ async fn run() -> Result<()> {
     let stream = mastodon.stream_user().await?;
     info!("watching mastodon for events. This will run forever, press Ctrl+C to kill the program.");
     stream
-        .try_for_each(|event| async move {
+        .try_for_each(|(event, _client)| async move {
             match event {
                 // fill in how you want to handle events here.
                 _ => warn!(event = as_serde!(event); "unrecognized event received"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@
 //! let client = Mastodon::from(data);
 //! tokio_test::block_on(async {
 //!     let stream = client.stream_user().await.unwrap();
-//!     stream.try_for_each(|event| async move {
+//!     stream.try_for_each(|(event, _client)| async move {
 //!         match event {
 //!             Event::Update(ref status) => { /* .. */ },
 //!             Event::Notification(ref notification) => { /* .. */ },

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -527,7 +527,8 @@ tokio_test::block_on(async {
     }).await.unwrap();
 });"
             ),
-            pub async fn $fn_name(&self) -> Result<impl TryStream<Ok=Event, Error=Error>> {
+            pub async fn $fn_name(&self) -> Result<impl TryStream<Ok=(Event, Mastodon), Error=Error> + '_> {
+                use $crate::event_stream::event_stream;
                 let url = self.route(&format!("/api/v1/streaming/{}", $stream));
                 let response = self.authenticated(self.client.get(&url)).header("Accept", "application/json").send().await?;
                 debug!(
@@ -537,7 +538,7 @@ tokio_test::block_on(async {
                 );
                 let status = response.status();
                 if status.is_success() {
-                     Ok(event_stream(response, url))
+                     Ok(event_stream(response, url, self))
                 } else {
                     let response = response.json().await?;
                     Err(Error::Api{ status, response })
@@ -575,7 +576,8 @@ tokio_test::block_on(async {
     }).await.unwrap();
 });"
             ),
-            pub async fn $fn_name(&self, $param: $param_type) -> Result<impl TryStream<Ok=Event, Error=Error>> {
+            pub async fn $fn_name(&self, $param: $param_type) -> Result<impl TryStream<Ok=(Event, Mastodon), Error=Error> + '_> {
+                use $crate::event_stream::event_stream;
                 let mut url: Url = self.route(concat!("/api/v1/streaming/", stringify!($stream))).parse()?;
                 url.query_pairs_mut().append_pair(stringify!($param), $param.as_ref());
                 let url = url.to_string();
@@ -587,7 +589,7 @@ tokio_test::block_on(async {
                 );
                 let status = response.status();
                 if status.is_success() {
-                     Ok(event_stream(response, url))
+                     Ok(event_stream(response, url, self))
                 } else {
                     let response = response.json().await?;
                     Err(Error::Api{ status, response })

--- a/src/mastodon.rs
+++ b/src/mastodon.rs
@@ -9,7 +9,6 @@ use crate::{
         Empty,
     },
     errors::{Error, Result},
-    event_stream::event_stream,
     helpers::read_response::read_response,
     log_serde,
     polling_time::PollingTime,


### PR DESCRIPTION
In order to be able to use the client to take action based on received events, the client needs passed to each loop invocation. Thankfully, we already use an `Arc` to make this cheap, as we have to clone it each time and provide a new owned instance.

Fixes #81.