### PR TITLE
Fix: derive `is_variant`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,10 +28,6 @@ edition.workspace = true
 [package.metadata.docs.rs]
 features = ["all"]
 
-[patch.crates-io.is_variant]
-git = "https://github.com/dscottboggs/rust_macro_is_variant.git"
-branch = "fixes"
-
 [dependencies.mastodon-async-entities]
 path = "./entities"
 version = "1.0.3"
@@ -48,7 +44,7 @@ static_assertions = "1.1.0"
 percent-encoding = "2.2.0"
 thiserror = "1.0.38"
 derive_deref = "1.1.1"
-is_variant = "1.0.0"
+derive_is_enum_variant = "0.1.1"
 
 [dependencies.parse_link_header]
 version = "0.3.3"

--- a/entities/Cargo.toml
+++ b/entities/Cargo.toml
@@ -13,7 +13,7 @@ edition.workspace = true
 futures = "0.3.25"
 thiserror = "1"
 static_assertions = "1"
-is_variant = "1.0.0"
+derive_is_enum_variant = "0.1.1"
 
 [dependencies.log]
 version = "0.4"

--- a/entities/src/attachment.rs
+++ b/entities/src/attachment.rs
@@ -1,7 +1,7 @@
 //! Module containing everything related to media attachements.
 
 use crate::AttachmentId;
-use is_variant::IsVariant;
+use derive_is_enum_variant::is_enum_variant;
 use serde::{Deserialize, Serialize};
 
 /// A struct representing a media attachment.
@@ -63,7 +63,7 @@ pub struct ImageDetails {
 }
 
 /// The type of media attachment.
-#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, IsVariant)]
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, is_enum_variant)]
 pub enum MediaType {
     /// An image.
     #[serde(rename = "image")]

--- a/entities/src/error.rs
+++ b/entities/src/error.rs
@@ -1,7 +1,7 @@
-use is_variant::IsVariant;
+use derive_is_enum_variant::is_enum_variant;
 
 /// Error type
-#[derive(Debug, thiserror::Error, IsVariant)]
+#[derive(Debug, thiserror::Error, is_enum_variant)]
 pub enum Error {
     #[error("unrecognized visibility '{invalid}'")]
     VisibilityParsingError { invalid: String },

--- a/entities/src/event.rs
+++ b/entities/src/event.rs
@@ -1,8 +1,8 @@
 use crate::{notification::Notification, status::Status};
-use is_variant::IsVariant;
+use derive_is_enum_variant::is_enum_variant;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Deserialize, Serialize, IsVariant)]
+#[derive(Debug, Clone, Deserialize, Serialize, is_enum_variant)]
 /// Events that come from the /streaming/user API call
 pub enum Event {
     /// Update event

--- a/entities/src/filter.rs
+++ b/entities/src/filter.rs
@@ -1,4 +1,4 @@
-use is_variant::IsVariant;
+use derive_is_enum_variant::is_enum_variant;
 use serde::{de::Visitor, Deserialize, Deserializer, Serialize};
 use time::{serde::iso8601, OffsetDateTime};
 
@@ -55,7 +55,7 @@ pub struct Filter {
 }
 
 /// Represents the various types of Filter contexts
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, IsVariant)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, is_enum_variant)]
 #[serde(rename_all = "lowercase")]
 pub enum FilterContext {
     /// Represents the "home" context
@@ -74,7 +74,7 @@ pub enum FilterContext {
 ///
 /// Please note that the spec requests that any unknown value be interpreted
 /// as "warn".
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, IsVariant)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, is_enum_variant)]
 #[serde(rename_all = "lowercase")]
 pub enum Action {
     /// Indicates filtered toots should show up, but with a warning

--- a/entities/src/notification.rs
+++ b/entities/src/notification.rs
@@ -3,7 +3,7 @@
 use crate::NotificationId;
 
 use super::{account::Account, status::Status};
-use is_variant::IsVariant;
+use derive_is_enum_variant::is_enum_variant;
 use serde::{Deserialize, Serialize};
 use time::{serde::iso8601, OffsetDateTime};
 
@@ -26,7 +26,7 @@ pub struct Notification {
 }
 
 /// The type of notification.
-#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, IsVariant)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, is_enum_variant)]
 #[serde(rename_all = "lowercase")]
 pub enum NotificationType {
     /// Someone mentioned the application client in another status.

--- a/entities/src/visibility.rs
+++ b/entities/src/visibility.rs
@@ -1,9 +1,9 @@
-use is_variant::IsVariant;
+use derive_is_enum_variant::is_enum_variant;
 use serde::Deserialize;
 use serde::Serialize;
 
 /// The visibility of a status.
-#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, IsVariant)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, is_enum_variant)]
 #[serde(rename_all = "lowercase")]
 pub enum Visibility {
     /// A Direct message to a user

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,9 +1,9 @@
 use std::string::FromUtf8Error;
 use std::{error, fmt, io::Error as IoError, num::TryFromIntError};
 
+use derive_is_enum_variant::is_enum_variant;
 #[cfg(feature = "env")]
 use envy::Error as EnvyError;
-use is_variant::IsVariant;
 use reqwest::{header::ToStrError as HeaderStrError, Error as HttpError, StatusCode};
 use serde::Deserialize;
 use serde_json::Error as SerdeError;
@@ -18,7 +18,7 @@ use url::ParseError as UrlError;
 pub type Result<T> = ::std::result::Result<T, Error>;
 
 /// enum of possible errors encountered using the mastodon API.
-#[derive(Debug, thiserror::Error, IsVariant)]
+#[derive(Debug, thiserror::Error, is_enum_variant)]
 pub enum Error {
     /// Error from the Mastodon API. This typically means something went
     /// wrong with your authentication or data.

--- a/src/scopes.rs
+++ b/src/scopes.rs
@@ -6,10 +6,10 @@ use std::{
     str::FromStr,
 };
 
-use is_variant::IsVariant;
 use serde::ser::{Serialize, Serializer};
 
 use crate::errors::Error;
+use derive_is_enum_variant::is_enum_variant;
 use serde::{
     de::{self, Visitor},
     Deserialize, Deserializer,
@@ -258,7 +258,7 @@ impl fmt::Display for Scopes {
 /// Permission scope of the application.
 /// [Details on what each permission provides][1]
 /// [1]: https://github.com/tootsuite/documentation/blob/master/Using-the-API/OAuth-details.md)
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, IsVariant)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, is_enum_variant)]
 #[serde(rename_all = "lowercase")]
 pub enum Scope {
     /// Read only permissions.
@@ -353,7 +353,7 @@ impl Default for Scope {
 }
 
 /// Represents the granular "read:___" oauth scopes
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, IsVariant)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, is_enum_variant)]
 pub enum Read {
     /// Accounts
     #[serde(rename = "accounts")]
@@ -448,7 +448,7 @@ impl fmt::Display for Read {
 }
 
 /// Represents the granular "write:___" oauth scopes
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, IsVariant)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, is_enum_variant)]
 pub enum Write {
     /// Accounts
     #[serde(rename = "accounts")]


### PR DESCRIPTION
The [`is_variant`](https://github.com/MihirLuthra/is_variant) crate has been abandoned in favor of [`derive_is_enum_variant`](https://crates.io/crates/derive_is_enum_variant)