### PR TITLE
build: set the rust msrv to 1.65

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ version = "1.2.1"
 license = "MIT/Apache-2.0"
 authors = ["Aaron Power <theaaronepower@gmail.com>", "Paul Woolcock <paul@woolcock.us>", "D. Scott Boggs <scott@tams.tech>"]
 edition = "2021"
+rust-version = "1.65"
 
 [package]
 name = "mastodon-async"
@@ -24,6 +25,7 @@ version.workspace = true
 license.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 features = ["all"]

--- a/entities/Cargo.toml
+++ b/entities/Cargo.toml
@@ -6,6 +6,7 @@ version.workspace = true
 license.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
necessary due to the use of workspace.package to handle inherited props
