### PR TITLE
Adding an explicit time >= 0.3.16

### DIFF
--- a/entities/Cargo.toml
+++ b/entities/Cargo.toml
@@ -25,7 +25,7 @@ version = "1"
 features = ["derive"]
 
 [dependencies.time]
-version = "0.3"
+version = ">=0.3.16"
 features = ["parsing", "serde", "formatting"]
 
 [dev-dependencies]


### PR DESCRIPTION
I ran into this when trying to add mastodon-async to a Tauri app.

Tauri forces time=0.3.15, which doesn't work with mastodon-async/entities, while 0.3.16 does.

This way, if anything forces a lower version, it shows as a version conflict, instead of a compilation error in -entities.