### PR TITLE
Disable default features for reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ features = ["serde"]
 [dependencies.reqwest]
 version = "0.11"
 features = ["multipart", "json", "stream"]
+default-features = false
 
 [dependencies.serde]
 version = "1"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ Alternatively, run the following command:
 $ cargo add mastodon-async
 ~~~
 
+### Use Rustls instead of OpenSSL
+
+To use Rustls instead of OpenSSL for HTTPS request, define the dependency as follows
+
+```toml
+mastodon-async = { version = "1", default-features = false, features = ["rustls-tls"] }
+```
+
 ## A Note on Debugging
 This library offers structured logging. To get better information about bugs or
 how something is working, I recommend adding the femme crate as a dependency,


### PR DESCRIPTION
Using `reqwest` with default-features enabled will enable the `default-tls`, which in turn will enable the `native-tls` feautre which will result in an attempt to compile against OpenSSL [0]. If one wants to use `mastodon-async` without depending on OpenSSL, the default features for `reqwest` must be disabled.

The default features for `mastodon-async` will enable `reqwest/default-tls`, so the default behaviour won't change, but now it is possible to declare the dependency on `mastodon-async` with default features disabled and the `rustls-tls` feature enabled, allowing to compile without a dependency on OpenSSL.

Fixes #105 

[0]: https://github.com/seanmonstar/reqwest/blob/e02df1f448d845fe01e6ea82c76ec89a59e5d568/Cargo.toml#L30