### PR TITLE
Status editing

### DIFF
--- a/src/mastodon.rs
+++ b/src/mastodon.rs
@@ -202,7 +202,7 @@ impl Mastodon {
             .send()
             .await?;
         debug!(
-            response = as_value!(response, Response),
+            response = as_value!(response, Response), updated_status_id = ?id, ?status,
             "received API response"
         );
         read_response(response).await

--- a/src/mastodon.rs
+++ b/src/mastodon.rs
@@ -46,7 +46,7 @@ impl From<Data> for Mastodon {
     }
 }
 impl Mastodon {
-    methods![get and get_with_call_id, post and post_with_call_id, put and put_with_call_id, delete and delete_with_call_id,];
+    methods![get and get_with_call_id, post and post_with_call_id, delete and delete_with_call_id,];
 
     paged_routes! {
         (get) favourites: "favourites" => Status,

--- a/src/mastodon.rs
+++ b/src/mastodon.rs
@@ -194,7 +194,7 @@ impl Mastodon {
     }
 
     /// Edit existing status
-    pub async fn edit_status(&self, id: &StatusId, status: NewStatus) -> Result<Status> {
+    pub async fn update_status(&self, id: &StatusId, status: NewStatus) -> Result<Status> {
         let url = self.route(format!("/api/v1/statuses/{}", id));
         let response = self
             .authenticated(self.client.put(&url))

--- a/src/mastodon.rs
+++ b/src/mastodon.rs
@@ -195,7 +195,7 @@ impl Mastodon {
 
     /// Edit existing status
     pub async fn update_status(&self, id: &StatusId, status: NewStatus) -> Result<Status> {
-        let url = self.route(format!("/api/v1/statuses/{}", id));
+        let url = self.route(format!("/api/v1/statuses/{id}"));
         let response = self
             .authenticated(self.client.put(&url))
             .json(&status)

--- a/src/mastodon.rs
+++ b/src/mastodon.rs
@@ -46,7 +46,7 @@ impl From<Data> for Mastodon {
     }
 }
 impl Mastodon {
-    methods![get and get_with_call_id, post and post_with_call_id, delete and delete_with_call_id,];
+    methods![get and get_with_call_id, post and post_with_call_id, put and put_with_call_id, delete and delete_with_call_id,];
 
     paged_routes! {
         (get) favourites: "favourites" => Status,
@@ -192,6 +192,22 @@ impl Mastodon {
 
         read_response(response).await
     }
+
+    /// Edit existing status
+    pub async fn edit_status(&self, id: &StatusId, status: NewStatus) -> Result<Status> {
+        let route = self.route(format!("/api/v1/statuses/{}", id));
+        let response = self
+            .authenticated(self.client.put(route))
+            .json(&status)
+            .send()
+            .await?;
+        debug!(
+            response = as_value!(response, Response),
+            "received API response"
+        );
+        read_response(response).await
+    }
+
 
     /// Post a new status to the account.
     pub async fn new_status(&self, status: NewStatus) -> Result<Status> {

--- a/src/mastodon.rs
+++ b/src/mastodon.rs
@@ -195,9 +195,9 @@ impl Mastodon {
 
     /// Edit existing status
     pub async fn edit_status(&self, id: &StatusId, status: NewStatus) -> Result<Status> {
-        let route = self.route(format!("/api/v1/statuses/{}", id));
+        let url = self.route(format!("/api/v1/statuses/{}", id));
         let response = self
-            .authenticated(self.client.put(route))
+            .authenticated(self.client.put(&url))
             .json(&status)
             .send()
             .await?;
@@ -207,7 +207,6 @@ impl Mastodon {
         );
         read_response(response).await
     }
-
 
     /// Post a new status to the account.
     pub async fn new_status(&self, status: NewStatus) -> Result<Status> {


### PR DESCRIPTION
This is related to the https://github.com/dscottboggs/mastodon-async/issues/112
Implemented as a separate function, not using `route...` macros because route requires both `id` and parameter. And there is no macros for such case, if I get it right. Please let me know, if I'm wrong :)
