### PR TITLE
Filters V2: allow to list, create and delete

### DIFF
--- a/entities/src/filter.rs
+++ b/entities/src/filter.rs
@@ -126,12 +126,12 @@ impl<'de> Deserialize<'de> for Action {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Keyword {
     /// The ID of the FilterKeyword in the database.
-    id: String,
+    pub id: String,
     /// The phrase to be matched against.
-    keyword: String,
+    pub keyword: String,
     /// Should the filter consider word boundaries? See [implementation guidelines
     /// for filters](https://docs.joinmastodon.org/api/guidelines/#filters).
-    whole_word: bool,
+    pub whole_word: bool,
 }
 
 /// Represents a status ID that, if matched, should cause the filter action to be taken.
@@ -146,9 +146,9 @@ pub struct Keyword {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Status {
     /// The ID of the FilterStatus in the database.
-    id: String,
+    pub id: String,
     /// The ID of the filtered Status in the database.
-    status_id: String,
+    pub status_id: String,
 }
 
 mod v1 {

--- a/src/helpers/read_response.rs
+++ b/src/helpers/read_response.rs
@@ -27,7 +27,9 @@ where
     loop {
         if let Ok(data) = timeout(Duration::from_secs(10), stream.next()).await {
             // as of here, we did not time out
-            let Some(data) = data else { break; };
+            let Some(data) = data else {
+                break;
+            };
             // as of here, we have not hit the end of the stream yet
             let data = data?;
             // as of here, we did not hit an error while reading the body

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,8 @@ pub use mastodon::{Mastodon, MastodonUnauthenticated};
 pub use mastodon_async_entities::visibility::Visibility;
 pub use registration::Registration;
 pub use requests::{
-    AddFilterRequest, AddPushRequest, StatusesRequest, UpdateCredsRequest, UpdatePushRequest,
+    AddFilterRequest, AddFilterV2Request, AddPushRequest, StatusesRequest, UpdateCredsRequest,
+    UpdatePushRequest,
 };
 pub use status_builder::{NewStatus, StatusBuilder};
 

--- a/src/requests/mod.rs
+++ b/src/requests/mod.rs
@@ -1,5 +1,5 @@
 /// Data structure for the MastodonClient::add_filter method
-pub use self::filter::AddFilterRequest;
+pub use self::filter::{AddFilterRequest, AddFilterV2Request};
 /// Data structure for the MastodonClient::add_push_subscription method
 pub use self::push::{AddPushRequest, Keys, UpdatePushRequest};
 /// Data structure for the MastodonClient::statuses method


### PR DESCRIPTION
For https://codeberg.org/xvello/mastoml I  needed to list, add and delete v2 filters through this client.

I did a quick and dirty addition first to unblock me, and wanted to check in with you @dscottboggs before polishing the PR for review:

- Will you have the time to review this PR?
- Should the methods & types around the v1 filters API be kept or removed? FYI, `get_filter` currently uses the v1 endpoint but the v2 type, and fails to unmarshall the response
- I can add a `update_v2_filter` query once the rest is merged

Feel free to directly push on the branch or suggest changes in a review.